### PR TITLE
Don't deserialize response after endpoint failure

### DIFF
--- a/runtime/protocol/client/RestConnector.go
+++ b/runtime/protocol/client/RestConnector.go
@@ -6,6 +6,7 @@
 package client
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -328,6 +329,13 @@ func (j *RestConnector) PrepareMethodResult(response *http.Response, restMetadat
 
 	// assign status code
 	j.statusCode = response.StatusCode
+	// TODO handle redirects
+	if j.statusCode >= 300 {
+		err := l10n.NewRuntimeError("vapi.protocol.client.request.error",
+			map[string]string{"errMsg": fmt.Sprintf("%s %s: %d", response.Request.Method, response.Request.URL.String(), j.statusCode)})
+		errVal := bindings.CreateErrorValueFromMessages(bindings.INVALID_REQUEST_ERROR_DEF, []error{err})
+		return core.NewMethodResult(nil, errVal)
+	}
 
 	respHeader := response.Header
 	responseBody := string(resp)


### PR DESCRIPTION
A non-2xx response assumes that the response body is not deserializable. Avoid a panic by returning a better error message instead of a panic from failing to deserialize. 

Signed-off-by: Brian Topping <brian@coglative.com>